### PR TITLE
feat(147154) ajuste teste unitarios para ms-relatorios

### DIFF
--- a/relatorios/tests/models/test_configuracao_relatorio_model.py
+++ b/relatorios/tests/models/test_configuracao_relatorio_model.py
@@ -1,0 +1,109 @@
+"""
+Testes unitários para o model ConfiguracaoRelatorio.
+"""
+import pytest
+from relatorios.models import ConfiguracaoRelatorio
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def configuracao():
+    config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='LAUDA_VAGAS')
+    config.cabecalho = ''
+    config.cabecalho_gabarito = ''
+    config.texto_final = ''
+    config.cabecalho_capa_ata = ''
+    config.usar_logotipo = False
+    config.save()
+    return config
+
+
+@pytest.fixture
+def configuracao_completa():
+    config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='SUMULA_ESCOLHAS')
+    config.usar_logotipo = True
+    config.cabecalho = '<h1>Cabeçalho</h1>'
+    config.cabecalho_gabarito = '<h1>Gabarito</h1>'
+    config.texto_final = '<p>Texto final</p>'
+    config.cabecalho_capa_ata = '<h2>Capa</h2>'
+    config.save()
+    return config
+
+
+class TestConfiguracaoRelatorioModel:
+
+    def test_criacao_com_defaults(self, configuracao):
+        assert configuracao.tipo == 'LAUDA_VAGAS'
+        assert configuracao.usar_logotipo is False
+        assert configuracao.cabecalho == ''
+        assert configuracao.cabecalho_gabarito == ''
+        assert configuracao.texto_final == ''
+        assert configuracao.cabecalho_capa_ata == ''
+
+    def test_uuid_gerado_automaticamente(self, configuracao):
+        assert configuracao.uuid is not None
+
+    def test_timestamps_gerados(self, configuracao):
+        assert configuracao.criado_em is not None
+        assert configuracao.atualizado_em is not None
+
+    def test_str(self, configuracao):
+        assert 'Lauda de Vagas' in str(configuracao)
+
+    def test_tipo_unico(self, configuracao):
+        from django.db import IntegrityError
+        with pytest.raises(IntegrityError):
+            ConfiguracaoRelatorio.objects.create(tipo=configuracao.tipo)
+
+    def test_ordering_por_tipo(self):
+        tipos = list(ConfiguracaoRelatorio.objects.values_list('tipo', flat=True))
+        assert tipos == sorted(tipos)
+
+    def test_db_table(self):
+        assert ConfiguracaoRelatorio._meta.db_table == 'relatorios_configuracao'
+
+
+class TestCabecalhoGabarito:
+
+    def test_cabecalho_gabarito_default_vazio(self, configuracao):
+        assert configuracao.cabecalho_gabarito == ''
+
+    def test_cabecalho_gabarito_salvo_e_recuperado(self):
+        html = '<h1>Cabeçalho Gabarito Teste</h1><p>Linha 2</p>'
+        config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='LAUDA_CONVOCACAO')
+        config.cabecalho_gabarito = html
+        config.save()
+        config.refresh_from_db()
+        assert config.cabecalho_gabarito == html
+
+    def test_cabecalho_gabarito_permite_blank(self):
+        config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='SUMULA_RECONVOCACAO')
+        config.cabecalho_gabarito = ''
+        config.save()
+        assert config.cabecalho_gabarito == ''
+
+    def test_cabecalho_gabarito_aceita_html_longo(self):
+        html_longo = '<div>' + '<p>Linha</p>' * 500 + '</div>'
+        config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='SUMULA_NAO_ESCOLHAS')
+        config.cabecalho_gabarito = html_longo
+        config.save()
+        config.refresh_from_db()
+        assert config.cabecalho_gabarito == html_longo
+
+    def test_cabecalho_gabarito_atualizavel(self, configuracao):
+        configuracao.cabecalho_gabarito = '<h2>Novo Gabarito</h2>'
+        configuracao.save()
+        configuracao.refresh_from_db()
+        assert configuracao.cabecalho_gabarito == '<h2>Novo Gabarito</h2>'
+
+    def test_todos_campos_coexistem(self, configuracao_completa):
+        assert configuracao_completa.cabecalho == '<h1>Cabeçalho</h1>'
+        assert configuracao_completa.cabecalho_gabarito == '<h1>Gabarito</h1>'
+        assert configuracao_completa.cabecalho_capa_ata == '<h2>Capa</h2>'
+        assert configuracao_completa.texto_final == '<p>Texto final</p>'
+
+    def test_verbose_name_cabecalho_gabarito(self):
+        field = ConfiguracaoRelatorio._meta.get_field('cabecalho_gabarito')
+        assert field.verbose_name == 'Cabeçalho Gabarito'

--- a/relatorios/tests/serializers/test_configuracao_relatorio_serializer.py
+++ b/relatorios/tests/serializers/test_configuracao_relatorio_serializer.py
@@ -1,0 +1,112 @@
+"""
+Testes unitários para o serializer ConfiguracaoRelatorioSerializer.
+"""
+import pytest
+from relatorios.models import ConfiguracaoRelatorio
+from relatorios.serializers import ConfiguracaoRelatorioSerializer
+
+
+pytestmark = pytest.mark.django_db
+
+CAMPOS_ESPERADOS = [
+    'uuid', 'tipo', 'usar_logotipo',
+    'cabecalho', 'cabecalho_gabarito', 'cabecalho_capa_ata',
+    'texto_final', 'criado_em', 'atualizado_em',
+]
+
+
+@pytest.fixture
+def configuracao():
+    config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='LAUDA_VAGAS')
+    config.cabecalho = '<h1>Cabeçalho</h1>'
+    config.cabecalho_gabarito = '<h1>Gabarito</h1>'
+    config.texto_final = '<p>Rodapé</p>'
+    config.cabecalho_capa_ata = ''
+    config.save()
+    return config
+
+
+class TestConfiguracaoRelatorioSerializer:
+
+    def test_campos_presentes_na_serializacao(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(configuracao)
+        for campo in CAMPOS_ESPERADOS:
+            assert campo in serializer.data, f"Campo '{campo}' ausente na serialização"
+
+    def test_uuid_somente_leitura(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(
+            configuracao,
+            data={'uuid': 'novo-uuid', 'tipo': 'LAUDA_VAGAS'},
+            partial=True,
+        )
+        assert serializer.is_valid()
+        instance = serializer.save()
+        assert str(instance.uuid) == str(configuracao.uuid)
+
+    def test_serializacao_cabecalho_gabarito(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(configuracao)
+        assert serializer.data['cabecalho_gabarito'] == '<h1>Gabarito</h1>'
+
+    def test_serializacao_cabecalho_gabarito_vazio(self):
+        config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='RELACAO_VAGAS')
+        config.cabecalho_gabarito = ''
+        config.save()
+        serializer = ConfiguracaoRelatorioSerializer(config)
+        assert serializer.data['cabecalho_gabarito'] == ''
+
+    def test_desserializacao_cabecalho_gabarito(self, configuracao):
+        novo_html = '<p>Novo Gabarito</p>'
+        serializer = ConfiguracaoRelatorioSerializer(
+            configuracao,
+            data={'cabecalho_gabarito': novo_html},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        instance = serializer.save()
+        assert instance.cabecalho_gabarito == novo_html
+
+    def test_desserializacao_cabecalho_gabarito_vazio(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(
+            configuracao,
+            data={'cabecalho_gabarito': ''},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        instance = serializer.save()
+        assert instance.cabecalho_gabarito == ''
+
+    def test_atualizacao_parcial_nao_afeta_outros_campos(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(
+            configuracao,
+            data={'cabecalho_gabarito': '<h2>Só o gabarito</h2>'},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        instance = serializer.save()
+        assert instance.cabecalho == '<h1>Cabeçalho</h1>'
+        assert instance.texto_final == '<p>Rodapé</p>'
+        assert instance.cabecalho_gabarito == '<h2>Só o gabarito</h2>'
+
+    def test_atualizacao_multiplos_campos_incluindo_gabarito(self, configuracao):
+        serializer = ConfiguracaoRelatorioSerializer(
+            configuracao,
+            data={
+                'cabecalho': '<h1>Novo Cabeçalho</h1>',
+                'cabecalho_gabarito': '<h1>Novo Gabarito</h1>',
+                'usar_logotipo': True,
+            },
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        instance = serializer.save()
+        assert instance.cabecalho == '<h1>Novo Cabeçalho</h1>'
+        assert instance.cabecalho_gabarito == '<h1>Novo Gabarito</h1>'
+        assert instance.usar_logotipo is True
+
+    def test_meta_fields_inclui_cabecalho_gabarito(self):
+        fields = ConfiguracaoRelatorioSerializer.Meta.fields
+        assert 'cabecalho_gabarito' in fields
+
+    def test_meta_read_only_nao_inclui_cabecalho_gabarito(self):
+        read_only = ConfiguracaoRelatorioSerializer.Meta.read_only_fields
+        assert 'cabecalho_gabarito' not in read_only

--- a/relatorios/tests/services/base/test_relatorio_base.py
+++ b/relatorios/tests/services/base/test_relatorio_base.py
@@ -16,7 +16,6 @@ def configuracao_relatorio():
         tipo='LAUDA_VAGAS',  # Tipo genérico para testes
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -36,6 +35,36 @@ def parametrizacao():
 class DummyRelatorio(RelatorioBase):
     def gerar(self, processo_uuid: str, request, formato: str = 'html', cabecalho: str = ''):
         return HttpResponse('ok'), {}
+
+
+def test_context_cabecalho_usa_gabarito_quando_cabecalho_vazio(configuracao_relatorio, parametrizacao):
+    configuracao_relatorio.cabecalho = ''
+    configuracao_relatorio.cabecalho_gabarito = 'Gabarito Teste'
+    configuracao_relatorio.save()
+
+    rel = DummyRelatorio(configuracao=configuracao_relatorio, parametrizacao=parametrizacao)
+
+    assert rel.context['cabecalho'] == 'Gabarito Teste'
+
+
+def test_context_cabecalho_prefere_cabecalho_sobre_gabarito(configuracao_relatorio, parametrizacao):
+    configuracao_relatorio.cabecalho = 'Cabeçalho Customizado'
+    configuracao_relatorio.cabecalho_gabarito = 'Gabarito Teste'
+    configuracao_relatorio.save()
+
+    rel = DummyRelatorio(configuracao=configuracao_relatorio, parametrizacao=parametrizacao)
+
+    assert rel.context['cabecalho'] == 'Cabeçalho Customizado'
+
+
+def test_context_cabecalho_vazio_quando_ambos_vazios(configuracao_relatorio, parametrizacao):
+    configuracao_relatorio.cabecalho = ''
+    configuracao_relatorio.cabecalho_gabarito = ''
+    configuracao_relatorio.save()
+
+    rel = DummyRelatorio(configuracao=configuracao_relatorio, parametrizacao=parametrizacao)
+
+    assert rel.context['cabecalho'] == '' or rel.context['cabecalho'] is None
 
 
 def test_render_to_pdf_success(monkeypatch, configuracao_relatorio, parametrizacao):

--- a/relatorios/tests/services/relatorios/conftest.py
+++ b/relatorios/tests/services/relatorios/conftest.py
@@ -30,19 +30,29 @@ if 'docx' not in sys.modules:
     mock_enum_text.WD_ALIGN_PARAGRAPH = MagicMock()
     mock_enum_text.WD_ALIGN_PARAGRAPH.CENTER = 'CENTER'
     mock_enum_text.WD_ALIGN_PARAGRAPH.LEFT = 'LEFT'
+
+    # Mock docx.enum.section
+    mock_enum_section = MagicMock()
+    mock_wd_orient = MagicMock()
+    mock_wd_orient.LANDSCAPE = 1
+    mock_wd_orient.PORTRAIT = 0
+    mock_enum_section.WD_ORIENT = mock_wd_orient
+
     mock_docx.enum = MagicMock()
     mock_docx.enum.text = mock_enum_text
-    
+    mock_docx.enum.section = mock_enum_section
+
     # Mock docx.oxml
     mock_oxml = MagicMock()
     mock_oxml.ns = MagicMock()
     mock_oxml.ns.qn = MagicMock(return_value='w:shd')
     mock_oxml.OxmlElement = MagicMock(return_value=MagicMock())
     mock_docx.oxml = mock_oxml
-    
+
     sys.modules['docx'] = mock_docx
     sys.modules['docx.shared'] = mock_shared
     sys.modules['docx.enum'] = mock_docx.enum
     sys.modules['docx.enum.text'] = mock_enum_text
+    sys.modules['docx.enum.section'] = mock_enum_section
     sys.modules['docx.oxml'] = mock_oxml
     sys.modules['docx.oxml.ns'] = mock_oxml.ns

--- a/relatorios/tests/services/relatorios/test_ata_escolha.py
+++ b/relatorios/tests/services/relatorios/test_ata_escolha.py
@@ -18,7 +18,6 @@ def configuracao_relatorio():
         tipo='ATA_ESCOLHA',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -248,33 +247,30 @@ def test_gerar_formatos(settings_config, service_mocked, dados_ata, request_obj,
     assert dados == dados_ata
 
 
-def test_gerar_html_uses_default_header_when_empty(settings_config, service_mocked, dados_ata, request_obj):
-    """Testa que usa cabeçalho padrão quando não fornecido."""
-    settings_config.RELATORIO_CABECALHO_PADRAO = 'CABECALHO_PADRAO'
+def test_gerar_html_uses_cabecalho_padrao_quando_vazio(settings_config, service_mocked, dados_ata, request_obj):
+    """Testa que usa cabecalho_padrao da Parametrizacao quando cabecalho está vazio."""
+    service_mocked.context['cabecalho_padrao'] = 'CABECALHO_PADRAO'
     service_mocked.ata_service.processar_ata_escolha.return_value = dados_ata
     with patch('relatorios.services.relatorios.ata_escolha.render', return_value=HttpResponse('OK')) as m_render:
         service_mocked.gerar(processo_uuid='proc-123', request=request_obj, formato='html', cabecalho='')
     context = m_render.call_args[0][2] if len(m_render.call_args[0]) >= 3 else m_render.call_args[1].get('context')
-    assert context['cabecalho'] == 'CABECALHO_PADRAO'
+    assert context['cabecalho_padrao'] == 'CABECALHO_PADRAO'
 
 
 @pytest.mark.parametrize('cabecalho,esperado', [
     ('  CABECALHO  ', 'CABECALHO'),
-    (None, 'PADRAO'),
+    (None, 'Cabeçalho Padrão Teste'),
 ])
 def test_gerar_cabecalho_tratamento(settings_config, service_mocked, dados_ata, request_obj, cabecalho, esperado):
-    """Testa tratamento de cabeçalho (stripped e None)."""
-    settings_config.RELATORIO_CABECALHO_PADRAO = 'PADRAO'
+    """Testa tratamento de cabeçalho (stripped) e uso de cabecalho_padrao quando vazio."""
     service_mocked.ata_service.processar_ata_escolha.return_value = dados_ata
     with patch('relatorios.services.relatorios.ata_escolha.render', return_value=HttpResponse('OK')) as m_render:
         service_mocked.gerar(processo_uuid='proc-123', request=request_obj, formato='html', cabecalho=cabecalho)
     context = m_render.call_args[0][2] if len(m_render.call_args[0]) >= 3 else m_render.call_args[1].get('context')
-    # O cabeçalho é processado pelo método gerar
     if cabecalho and cabecalho.strip():
         assert context['cabecalho'] == esperado
     else:
-        # Usa cabeçalho padrão se None ou vazio
-        assert context['cabecalho'] == esperado or context['cabecalho'] == 'PADRAO'
+        assert context['cabecalho_padrao'] == esperado
 
 
 def test_gerar_raises_exception_on_service_failure(settings_config, service_mocked, request_obj):

--- a/relatorios/tests/services/relatorios/test_lauda_convocacao.py
+++ b/relatorios/tests/services/relatorios/test_lauda_convocacao.py
@@ -17,7 +17,6 @@ def configuracao_relatorio():
         tipo='LAUDA_CONVOCACAO',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -65,7 +64,6 @@ def test_gerar_html_calls_render_with_context_and_default_header(settings, confi
     settings.CANDIDATOS_API_URL = 'http://candidatos'
     settings.CONVOCACAO_API_URL = 'http://processos'
     settings.AGENDAS_API_URL = 'http://agendas'
-    settings.RELATORIO_CABECALHO_PADRAO = 'HEADER_PADRAO'
 
     svc = LaudaConvocacao(
         configuracao=configuracao_relatorio,
@@ -78,10 +76,10 @@ def test_gerar_html_calls_render_with_context_and_default_header(settings, confi
         response, dados = svc.gerar(processo_uuid='xyz', request=_make_request(), formato='html', cabecalho='')
 
     assert isinstance(response, HttpResponse)
-    # Verifica que o contexto enviado para render inclui o cabeçalho padrão
+    # Verifica que o contexto enviado para render inclui o cabecalho_padrao da Parametrizacao
     _, args, kwargs = m_render.mock_calls[0]
     context = args[2] if len(args) >= 3 else kwargs.get('context')
-    assert context['cabecalho'] == 'HEADER_PADRAO'
+    assert context['cabecalho_padrao'] == 'Cabeçalho Padrão Teste'
     assert dados == {'cargos': []}
 
 

--- a/relatorios/tests/services/relatorios/test_lista_candidatos_sessao.py
+++ b/relatorios/tests/services/relatorios/test_lista_candidatos_sessao.py
@@ -26,7 +26,6 @@ def configuracao_relatorio():
         tipo='LISTA_CANDIDATOS_SESSAO',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -173,7 +172,7 @@ def test_docx_importerror_when_lib_missing(settings, monkeypatch, configuracao_r
         svc.gerar('p1', _req(), 'docx', cabecalho='', agenda_uuid='ag-1')
 
 
-def test_header_fallback_uses_settings_default(settings, monkeypatch, configuracao_relatorio, parametrizacao):
+def test_header_padrao_aparece_automaticamente(settings, monkeypatch, configuracao_relatorio, parametrizacao):
     svc = _make_service(settings, configuracao_relatorio, parametrizacao)
     monkeypatch.setattr(svc.candidatos_service, 'buscar_por_uuids', lambda **kw: _Resp([]))
     monkeypatch.setattr(
@@ -181,15 +180,13 @@ def test_header_fallback_uses_settings_default(settings, monkeypatch, configurac
         'buscar_agenda_por_uuid',
         lambda agenda_uuid: _Resp({'candidatos_uuids': [], 'retardatario': False})
     )
-    # Configurar para usar cabeçalho padrão
-    svc.context['usar_cabecalho_padrao'] = True
+    # Cabeçalho padrão sempre aparece se preenchido (sem necessidade de flag)
     parametrizacao.cabecalho = 'HEADER_PADRAO'
     parametrizacao.save()
     svc.context['cabecalho_padrao'] = 'HEADER_PADRAO'
-    
+
     response, ctx = svc.gerar('p1', _req(), 'html', cabecalho=None, agenda_uuid='ag-1')
-    # O cabecalho vem de self.context
-    assert svc.context.get('cabecalho') == 'HEADER_PADRAO'
+    assert svc.context.get('cabecalho_padrao') == 'HEADER_PADRAO'
 
 def test_multiple_agendas_filtered_and_separated(settings, monkeypatch, configuracao_relatorio, parametrizacao):
     svc = _make_service(settings, configuracao_relatorio, parametrizacao)
@@ -612,23 +609,25 @@ def test_render_xls_layout_with_title_and_agenda(settings, monkeypatch, configur
     assert resp['Content-Type'] == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     ws = mod._last_ws
     cells = ws._cells
-    # Título na 1a linha
-    assert cells[(1, 1)].value == 'Lista de Candidatos por Sessão'
+    # cabecalho_padrao na linha 1 (sempre exibido se preenchido)
+    assert cells[(1, 1)].value == 'Cabeçalho Padrão Teste'
+    # Título na linha 3 (deslocado 2 linhas pelo cabecalho_padrao)
+    assert cells[(3, 1)].value == 'Lista de Candidatos por Sessão'
     # Data, horário e sessão nas linhas seguintes
-    assert str(cells[(3, 1)].value).startswith('Data: ')
-    assert '13/01/2026' in str(cells[(3, 1)].value)
-    assert str(cells[(4, 1)].value).startswith('Horário:')
-    assert '08:00' in str(cells[(4, 1)].value) and '09:00' in str(cells[(4, 1)].value)
-    assert cells[(5, 1)].value == '1'
-    # Cabeçalho na linha 7
-    assert cells[(7, 1)].value == 'Classificação'
-    assert cells[(7, 2)].value == 'Classificação NNA'
-    assert cells[(7, 3)].value == 'Classificação PCD'
-    assert cells[(7, 4)].value == 'Inscrição'
-    assert cells[(7, 5)].value == 'Nome'
-    assert cells[(7, 6)].value == 'CPF'
-    # Primeira linha de dados na 8a linha
-    assert cells[(8, 1)].value == 10
-    assert cells[(8, 4)].value == 'I1'
-    assert cells[(8, 5)].value == 'Nome 1'
-    assert cells[(8, 6)].value == '111'
+    assert str(cells[(5, 1)].value).startswith('Data: ')
+    assert '13/01/2026' in str(cells[(5, 1)].value)
+    assert str(cells[(6, 1)].value).startswith('Horário:')
+    assert '08:00' in str(cells[(6, 1)].value) and '09:00' in str(cells[(6, 1)].value)
+    assert cells[(7, 1)].value == '1'
+    # Cabeçalho de colunas na linha 9
+    assert cells[(9, 1)].value == 'Classificação'
+    assert cells[(9, 2)].value == 'Classificação NNA'
+    assert cells[(9, 3)].value == 'Classificação PCD'
+    assert cells[(9, 4)].value == 'Inscrição'
+    assert cells[(9, 5)].value == 'Nome'
+    assert cells[(9, 6)].value == 'CPF'
+    # Primeira linha de dados na linha 10
+    assert cells[(10, 1)].value == 10
+    assert cells[(10, 4)].value == 'I1'
+    assert cells[(10, 5)].value == 'Nome 1'
+    assert cells[(10, 6)].value == '111'

--- a/relatorios/tests/services/relatorios/test_listagem_escolhas_dres.py
+++ b/relatorios/tests/services/relatorios/test_listagem_escolhas_dres.py
@@ -23,7 +23,6 @@ def configuracao_relatorio():
         tipo='LISTAGEM_ESCOLHAS_DRES',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -271,12 +270,11 @@ class TestGerar:
         mock_candidatos_response,
         mock_escolhas_response
     ):
-        """Testa que usa cabeçalho padrão quando não fornecido."""
+        """Testa que usa cabeçalho padrão automaticamente quando preenchido."""
         listagem_escolhas_dres_service.candidatos_service.buscar_concurso_candidatos_por_processo.return_value = mock_candidatos_response
         listagem_escolhas_dres_service.escolhas_service.buscar_escolhas_por_candidatos.return_value = mock_escolhas_response
-        listagem_escolhas_dres_service.context['usar_cabecalho_padrao'] = True
         listagem_escolhas_dres_service.context['cabecalho_padrao'] = 'Cabeçalho Padrão'
-        
+
         with patch('relatorios.services.relatorios.listagem_escolhas_dres.render', return_value=HttpResponse('OK')) as m_render:
             response, dados = listagem_escolhas_dres_service.gerar(
                 processo_uuid='proc-123',
@@ -284,10 +282,10 @@ class TestGerar:
                 formato='html',
                 cabecalho=''
             )
-        
+
         _, args, kwargs = m_render.mock_calls[0]
         context = args[2] if len(args) >= 3 else kwargs.get('context')
-        assert context['cabecalho'] == 'Cabeçalho Padrão'
+        assert context['cabecalho_padrao'] == 'Cabeçalho Padrão'
     
     def test_gerar_erro_buscar_candidatos(
         self,

--- a/relatorios/tests/services/relatorios/test_resultado_escolha.py
+++ b/relatorios/tests/services/relatorios/test_resultado_escolha.py
@@ -143,7 +143,6 @@ def configuracao_relatorio():
         tipo='RESULTADO_ESCOLHA',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': 'Cabeçalho Teste',
             'texto_final': 'Texto Final Teste',
             'cabecalho_capa_ata': '',
@@ -508,9 +507,7 @@ class TestGerar:
         mock_candidatos_response,
         mock_escolhas_response
     ):
-        """Testa que usa cabeçalho padrão quando não fornecido."""
-        # Configurar para usar cabeçalho padrão
-        resultado_escolha_service.context['usar_cabecalho_padrao'] = True
+        """Testa que usa cabeçalho padrão automaticamente quando preenchido."""
         resultado_escolha_service.context['cabecalho_padrao'] = 'Cabeçalho Padrão'
         
         resultado_escolha_service.processos_service.buscar_cargos_por_processo.return_value = mock_cargos_response
@@ -534,7 +531,7 @@ class TestGerar:
         
         _, args, kwargs = m_render.mock_calls[0]
         context = args[2] if len(args) >= 3 else kwargs.get('context')
-        assert context['cabecalho'] == 'Cabeçalho Padrão'
+        assert context['cabecalho_padrao'] == 'Cabeçalho Padrão'
     
     def test_gerar_tipo_resultado_escolha_unificado(
         self,
@@ -1275,7 +1272,6 @@ class TestGerar:
         config_invalida = ConfiguracaoRelatorio.objects.create(
             tipo='TIPO_INVALIDO',
             usar_logotipo=False,
-            usar_cabecalho_padrao=False,
             cabecalho='',
             texto_final='',
             cabecalho_capa_ata=''
@@ -1482,7 +1478,8 @@ class TestGerar:
                 resultado_escolha_service.render_to_xls(
                     cargos_list,
                     'Cabeçalho',
-                    'test.xlsx'
+                    '',
+                    filename='test.xlsx'
                 )
 
 
@@ -1516,9 +1513,10 @@ class TestRenderToXls:
         response = resultado_escolha_service.render_to_xls(
             cargos_list,
             'Cabeçalho Teste',
-            'test.xlsx'
+            '',
+            filename='test.xlsx'
         )
-        
+
         assert isinstance(response, HttpResponse)
         assert 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' in response['Content-Type']
         assert 'attachment' in response['Content-Disposition']
@@ -1536,11 +1534,12 @@ class TestRenderToXls:
         response = resultado_escolha_service.render_to_xls(
             cargos_list,
             '',
-            'test.xlsx'
+            '',
+            filename='test.xlsx'
         )
-        
+
         assert isinstance(response, HttpResponse)
-    
+
     def test_render_to_xls_multiplos_cargos(self, resultado_escolha_service):
         """Testa geração de Excel com múltiplos cargos."""
         cargos_list = [
@@ -1567,11 +1566,12 @@ class TestRenderToXls:
         response = resultado_escolha_service.render_to_xls(
             cargos_list,
             'Cabeçalho',
-            'test.xlsx'
+            '',
+            filename='test.xlsx'
         )
-        
+
         assert isinstance(response, HttpResponse)
-    
+
     @patch('relatorios.services.relatorios.resultado_escolha.OPENPYXL_AVAILABLE', False)
     def test_render_to_xls_openpyxl_nao_disponivel(self, resultado_escolha_service):
         """Testa erro quando openpyxl não está disponível."""
@@ -1581,7 +1581,8 @@ class TestRenderToXls:
             resultado_escolha_service.render_to_xls(
                 cargos_list,
                 'Cabeçalho',
-                'test.xlsx'
+                '',
+                filename='test.xlsx'
             )
 
 
@@ -2420,7 +2421,7 @@ class TestRenderToXlsResumoDreEscola:
             }
         ]
         
-        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
         assert 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' in response['Content-Type']
@@ -2438,7 +2439,7 @@ class TestRenderToXlsResumoDreEscola:
             mock_response.raise_for_status = Mock()
             mock_get.return_value = mock_response
             
-            response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+            response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
     
@@ -2448,7 +2449,7 @@ class TestRenderToXlsResumoDreEscola:
         
         cargos_list = [{'codigo': '123', 'descricao': 'Professor', 'tipos_escolha': []}]
         
-        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
 
@@ -2506,7 +2507,6 @@ class TestTiposAntigosCompatibilidade:
             tipo='RESULTADO_ESCOLHA_SIM',
             defaults={
                 'usar_logotipo': False,
-                'usar_cabecalho_padrao': False,
                 'cabecalho': '',
                 'texto_final': '',
                 'cabecalho_capa_ata': ''
@@ -2569,7 +2569,7 @@ class TestTiposAntigosCompatibilidade:
             }
         ]
         
-        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
     
@@ -2606,7 +2606,7 @@ class TestTiposAntigosCompatibilidade:
         cargos_list = [{'codigo': '123', 'descricao': 'Professor', 'tipos_escolha': []}]
         
         with patch('relatorios.services.relatorios.resultado_escolha.requests.get', side_effect=Exception('Erro')):
-            response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+            response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
     
@@ -2619,7 +2619,7 @@ class TestTiposAntigosCompatibilidade:
         
         cargos_list = [{'codigo': '123', 'descricao': 'Professor', 'tipos_escolha': []}]
         
-        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
     
@@ -2655,7 +2655,7 @@ class TestTiposAntigosCompatibilidade:
             }
         ]
         
-        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho')
+        response = resultado_escolha_service.render_to_xls(cargos_list, 'Cabeçalho', '')
         
         assert isinstance(response, HttpResponse)
     

--- a/relatorios/tests/services/relatorios/test_sumula_escolhas.py
+++ b/relatorios/tests/services/relatorios/test_sumula_escolhas.py
@@ -20,7 +20,6 @@ def configuracao_relatorio():
         tipo='SUMULA_ESCOLHAS',
         defaults={
             'usar_logotipo': False,
-            'usar_cabecalho_padrao': False,
             'cabecalho': '',
             'texto_final': '',
             'cabecalho_capa_ata': ''
@@ -295,13 +294,12 @@ class TestGerar:
         mock_candidatos_response,
         mock_escolhas_response
     ):
-        """Testa que usa cabeçalho padrão quando não fornecido."""
+        """Testa que usa cabeçalho padrão automaticamente quando preenchido."""
         sumula_escolhas_service.processos_service.buscar_cargos_por_processo.return_value = mock_cargos_response
         sumula_escolhas_service.candidatos_service.buscar_concurso_candidatos_por_processo.return_value = mock_candidatos_response
         sumula_escolhas_service.escolhas_service.buscar_escolhas_por_candidatos.return_value = mock_escolhas_response
-        sumula_escolhas_service.context['usar_cabecalho_padrao'] = True
         sumula_escolhas_service.context['cabecalho_padrao'] = 'Cabeçalho Padrão'
-        
+
         with patch('relatorios.services.relatorios.sumula_escolhas.render', return_value=HttpResponse('OK')) as m_render:
             response, dados = sumula_escolhas_service.gerar(
                 processo_uuid='proc-123',
@@ -309,10 +307,10 @@ class TestGerar:
                 formato='html',
                 cabecalho=''
             )
-        
+
         _, args, kwargs = m_render.mock_calls[0]
         context = args[2] if len(args) >= 3 else kwargs.get('context')
-        assert context['cabecalho'] == 'Cabeçalho Padrão'
+        assert context['cabecalho_padrao'] == 'Cabeçalho Padrão'
     
     def test_gerar_filtra_escolhas_realizadas(
         self,

--- a/relatorios/tests/views/test_personalizacao.py
+++ b/relatorios/tests/views/test_personalizacao.py
@@ -1,0 +1,155 @@
+"""
+Testes unitários para o PersonalizacaoViewSet.
+"""
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from relatorios.models import ConfiguracaoRelatorio
+
+
+pytestmark = pytest.mark.django_db
+
+CAMPOS_ESPERADOS = [
+    'uuid', 'tipo', 'usar_logotipo',
+    'cabecalho', 'cabecalho_gabarito', 'cabecalho_capa_ata',
+    'texto_final', 'criado_em', 'atualizado_em',
+]
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def configuracao_lauda_vagas():
+    config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='LAUDA_VAGAS')
+    config.cabecalho = '<h1>Cabeçalho</h1>'
+    config.cabecalho_gabarito = '<h1>Gabarito Lauda</h1>'
+    config.texto_final = '<p>Rodapé</p>'
+    config.save()
+    return config
+
+
+@pytest.fixture
+def configuracao_ata_escolha():
+    config, _ = ConfiguracaoRelatorio.objects.get_or_create(tipo='ATA_ESCOLHA')
+    config.cabecalho_gabarito = '<h1>Gabarito Ata</h1>'
+    config.cabecalho_capa_ata = '<h2>Capa da Ata</h2>'
+    config.save()
+    return config
+
+
+class TestPersonalizacaoListagem:
+
+    def test_list_retorna_200(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'LAUDA_VAGAS'})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_list_retorna_cabecalho_gabarito(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'LAUDA_VAGAS'})
+        assert response.data['cabecalho_gabarito'] == '<h1>Gabarito Lauda</h1>'
+
+    def test_list_retorna_todos_campos_esperados(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'LAUDA_VAGAS'})
+        for campo in CAMPOS_ESPERADOS:
+            assert campo in response.data, f"Campo '{campo}' ausente na resposta"
+
+    def test_list_sem_filtro_retorna_primeira_configuracao(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-list')
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert 'cabecalho_gabarito' in response.data
+
+    def test_list_tipo_invalido_retorna_400(self, client):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'TIPO_INEXISTENTE'})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestPersonalizacaoAtualizacao:
+
+    def test_patch_atualiza_cabecalho_gabarito(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        novo_gabarito = '<h2>Gabarito Atualizado</h2>'
+        response = client.patch(url, {'cabecalho_gabarito': novo_gabarito}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        configuracao_lauda_vagas.refresh_from_db()
+        assert configuracao_lauda_vagas.cabecalho_gabarito == novo_gabarito
+
+    def test_patch_retorna_cabecalho_gabarito_atualizado(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        novo_gabarito = '<h2>Retorno Gabarito</h2>'
+        response = client.patch(url, {'cabecalho_gabarito': novo_gabarito}, format='json')
+        assert response.data['cabecalho_gabarito'] == novo_gabarito
+
+    def test_patch_limpa_cabecalho_gabarito(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        response = client.patch(url, {'cabecalho_gabarito': ''}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        configuracao_lauda_vagas.refresh_from_db()
+        assert configuracao_lauda_vagas.cabecalho_gabarito == ''
+
+    def test_patch_cabecalho_gabarito_nao_afeta_outros_campos(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        response = client.patch(url, {'cabecalho_gabarito': '<h2>Só gabarito</h2>'}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        configuracao_lauda_vagas.refresh_from_db()
+        assert configuracao_lauda_vagas.cabecalho == '<h1>Cabeçalho</h1>'
+        assert configuracao_lauda_vagas.texto_final == '<p>Rodapé</p>'
+
+    def test_patch_multiples_campos_com_gabarito(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        payload = {
+            'cabecalho': '<h1>Cabeçalho Novo</h1>',
+            'cabecalho_gabarito': '<h1>Gabarito Novo</h1>',
+            'usar_logotipo': True,
+        }
+        response = client.patch(url, payload, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        configuracao_lauda_vagas.refresh_from_db()
+        assert configuracao_lauda_vagas.cabecalho == '<h1>Cabeçalho Novo</h1>'
+        assert configuracao_lauda_vagas.cabecalho_gabarito == '<h1>Gabarito Novo</h1>'
+        assert configuracao_lauda_vagas.usar_logotipo is True
+
+    def test_patch_ata_escolha_com_cabecalho_gabarito_e_capa(self, client, configuracao_ata_escolha):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_ata_escolha.uuid)})
+        payload = {
+            'cabecalho_gabarito': '<h1>Gabarito Ata Atualizado</h1>',
+            'cabecalho_capa_ata': '<h2>Nova Capa</h2>',
+        }
+        response = client.patch(url, payload, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        configuracao_ata_escolha.refresh_from_db()
+        assert configuracao_ata_escolha.cabecalho_gabarito == '<h1>Gabarito Ata Atualizado</h1>'
+        assert configuracao_ata_escolha.cabecalho_capa_ata == '<h2>Nova Capa</h2>'
+
+    def test_patch_uuid_nao_alteravel(self, client, configuracao_lauda_vagas):
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(configuracao_lauda_vagas.uuid)})
+        uuid_original = str(configuracao_lauda_vagas.uuid)
+        response = client.patch(url, {'uuid': 'outro-uuid'}, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert str(response.data['uuid']) == uuid_original
+
+    def test_patch_uuid_inexistente_retorna_404(self, client):
+        import uuid
+        url = reverse('personalizacao-detail', kwargs={'uuid': str(uuid.uuid4())})
+        response = client.patch(url, {'cabecalho_gabarito': '<h1>x</h1>'}, format='json')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestPersonalizacaoFiltragemPorTipo:
+
+    def test_filtro_tipo_retorna_configuracao_correta(self, client, configuracao_lauda_vagas, configuracao_ata_escolha):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'ATA_ESCOLHA'})
+        assert response.data['cabecalho_gabarito'] == '<h1>Gabarito Ata</h1>'
+
+    def test_filtro_tipo_lauda_vagas(self, client, configuracao_lauda_vagas, configuracao_ata_escolha):
+        url = reverse('personalizacao-list')
+        response = client.get(url, {'tipo': 'LAUDA_VAGAS'})
+        assert response.data['cabecalho_gabarito'] == '<h1>Gabarito Lauda</h1>'


### PR DESCRIPTION
Adiciona teste unitários após ajuste do cabeçalho.

[AB#147003](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147003)
[AB#147154](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147154)
