### PR TITLE
feat(150059): Fluxo de extração de dados

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -224,6 +224,9 @@ CONVOCACAO_API_URL = os.environ.get(
 CANDIDATOS_API_URL = os.environ.get(
     "CANDIDATOS_API_URL", "http://localhost:8002"
 )
+CONCURSOS_API_URL = os.environ.get(
+    "CONCURSOS_API_URL", "http://localhost:8001"
+)
 AGENDAS_API_URL = os.environ.get("AGENDAS_API_URL", "http://localhost:8005")
 
 # Relatórios configuration

--- a/relatorios/serializers/__init__.py
+++ b/relatorios/serializers/__init__.py
@@ -1,6 +1,7 @@
 """Módulo serializers/__init__."""
 
 from .configuracao_relatorio import ConfiguracaoRelatorioSerializer
+from .extracao_dados import ExtracaoDadosQuerySerializer
 from .parametrizacao import ParametrizacaoSerializer
 from .relatorio_create import RelatorioCreateSerializer
 from .relatorio_get import RelatorioSerializer
@@ -10,4 +11,5 @@ __all__ = [
     "RelatorioSerializer",
     "ParametrizacaoSerializer",
     "ConfiguracaoRelatorioSerializer",
+    "ExtracaoDadosQuerySerializer",
 ]

--- a/relatorios/serializers/__init__.py
+++ b/relatorios/serializers/__init__.py
@@ -1,4 +1,5 @@
 from .configuracao_relatorio import ConfiguracaoRelatorioSerializer
+from .extracao_dados import ExtracaoDadosQuerySerializer
 from .parametrizacao import ParametrizacaoSerializer
 from .relatorio_create import RelatorioCreateSerializer
 from .relatorio_get import RelatorioSerializer
@@ -8,4 +9,5 @@ __all__ = [
     "RelatorioSerializer",
     "ParametrizacaoSerializer",
     "ConfiguracaoRelatorioSerializer",
+    "ExtracaoDadosQuerySerializer",
 ]

--- a/relatorios/serializers/extracao_dados.py
+++ b/relatorios/serializers/extracao_dados.py
@@ -1,0 +1,12 @@
+"""
+Serializer para validação dos parâmetros de entrada da extração de dados.
+"""
+
+from rest_framework import serializers
+
+
+class ExtracaoDadosQuerySerializer(serializers.Serializer):
+    """Valida os query params do endpoint GET extracao-dados."""
+
+    concurso_uuid = serializers.UUIDField(required=True)
+    ano = serializers.IntegerField(required=True, min_value=1000, max_value=9999)

--- a/relatorios/services/candidatos_api_service.py
+++ b/relatorios/services/candidatos_api_service.py
@@ -330,6 +330,74 @@ class CandidatosService:
         )
         return response
 
+    def buscar_extracao_dados(
+        self,
+        concurso_uuid: str | None = None,
+        filtros: list[dict] | None = None,
+    ) -> dict:
+        """
+        Busca dados de extração de habilitados e convocados agrupados por ano/processo.
+
+        Endpoint esperado do ms-candidatos:
+            POST /api/v1/habilitados/extracao-dados/
+
+        Args:
+            concurso_uuid: UUID do concurso
+            filtros: Lista de filtros com ano e processo_uuids
+
+        Returns:
+            Dados da API com extração
+
+        Raises:
+            RequestException: Em caso de erro na requisição
+        """
+        url = f"{self.base_url}/api/v1/habilitados/extracao-dados/"
+        payload = {}
+        if concurso_uuid is not None:
+            payload["concurso_uuid"] = concurso_uuid
+        if filtros is not None:
+            payload["filtros"] = filtros
+        logger.info(
+            "Buscando totais de habilitados por processo e ano",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+            },
+        )
+        try:
+            response = http_client.post(
+                url,
+                json=payload,
+                headers=self._default_headers,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+        except RequestException as exc:
+            logger.error(
+                "Erro ao buscar totais de habilitados por processo e ano "
+                "(concurso_uuid=%s): %s",
+                concurso_uuid,
+                exc,
+            )
+            raise
+
+        logger.info(
+            "Totais de habilitados por processo e ano buscados com sucesso",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+                "status_code": response.status_code,
+                "response": str(response.json())[:100],
+            },
+        )
+        return response.json()
+
     def buscar_candidatos_por_agendas(
         self,
         agendas_response: requests.Response,

--- a/relatorios/services/candidatos_api_service.py
+++ b/relatorios/services/candidatos_api_service.py
@@ -277,6 +277,74 @@ class CandidatosService:
         )
         return response  # type: ignore[no-any-return]
 
+    def buscar_extracao_dados(
+        self,
+        concurso_uuid: str | None = None,
+        filtros: list[dict] | None = None,
+    ) -> dict:
+        """
+        Busca dados de extração de habilitados e convocados agrupados por ano/processo.
+
+        Endpoint esperado do ms-candidatos:
+            POST /api/v1/habilitados/extracao-dados/
+
+        Args:
+            concurso_uuid: UUID do concurso
+            filtros: Lista de filtros com ano e processo_uuids
+
+        Returns:
+            Dados da API com extração
+
+        Raises:
+            RequestException: Em caso de erro na requisição
+        """
+        url = f"{self.base_url}/api/v1/habilitados/extracao-dados/"
+        payload = {}
+        if concurso_uuid is not None:
+            payload["concurso_uuid"] = concurso_uuid
+        if filtros is not None:
+            payload["filtros"] = filtros
+        logger.info(
+            "Buscando totais de habilitados por processo e ano",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+            },
+        )
+        try:
+            response = http_client.post(
+                url,
+                json=payload,
+                headers=self._default_headers,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+        except RequestException as exc:
+            logger.error(
+                "Erro ao buscar totais de habilitados por processo e ano "
+                "(concurso_uuid=%s): %s",
+                concurso_uuid,
+                exc,
+            )
+            raise
+
+        logger.info(
+            "Totais de habilitados por processo e ano buscados com sucesso",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+                "status_code": response.status_code,
+                "response": str(response.json())[:100],
+            },
+        )
+        return response.json()
+
     def buscar_candidatos_por_agendas(
         self,
         agendas_response: requests.Response,

--- a/relatorios/services/concurso_api_service.py
+++ b/relatorios/services/concurso_api_service.py
@@ -1,0 +1,95 @@
+"""
+Serviços para integração com API de concursos.
+"""
+
+import logging
+
+import requests
+from requests import RequestException
+from sigla_sdk.context import get_correlation_id
+from sigla_sdk.http.api_client import http_client
+
+logger = logging.getLogger(__name__)
+
+
+class ConcursoService:
+    """Service para integração com API de concursos."""
+
+    def __init__(
+        self, base_url: str = "https://example.com", timeout_seconds: int = 30
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self._default_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def buscar_extracao_dados(
+        self,
+        concurso_uuid: str | None = None,
+        ano: int | None = None,
+    ) -> dict:
+        """
+        Busca dados de extração do concurso.
+
+        Endpoint esperado do ms-concursos:
+            GET /api/v1/extracao-dados/
+
+        Args:
+            concurso_uuid: UUID do concurso (opcional)
+            ano: Ano de referência YYYY (opcional)
+
+        Returns:
+            Dados da API com extração do concurso
+
+        Raises:
+            RequestException: Em caso de erro na requisição
+        """
+        url = f"{self.base_url}/api/v1/extracao-dados/"
+        payload = {}
+        if concurso_uuid is not None:
+            payload["concurso_uuid"] = concurso_uuid
+        if ano is not None:
+            payload["ano"] = ano
+        logger.info(
+            "Buscando extração de dados em concursos",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "GET",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+            },
+        )
+        try:
+            response = http_client.post(
+                url,
+                json=payload,
+                headers=self._default_headers,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+        except RequestException as exc:
+            logger.error(
+                "Erro ao buscar extração de dados em concursos "
+                "(concurso_uuid=%s, ano=%s): %s",
+                concurso_uuid,
+                ano,
+                exc,
+            )
+            raise
+
+        logger.info(
+            "Extração de dados em concursos buscada com sucesso",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "GET",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+                "status_code": response.status_code,
+                "response": str(response.json())[:100],
+            },
+        )
+        return response.json()

--- a/relatorios/services/escolhas_api_service.py
+++ b/relatorios/services/escolhas_api_service.py
@@ -150,3 +150,71 @@ class EscolhasService:
             len(escolhas_filtradas),
         )
         return escolhas_filtradas
+
+    def buscar_extracao_dados(
+        self,
+        concurso_uuid: str | None = None,
+        filtros: list[dict] | None = None,
+    ) -> dict:
+        """
+        Busca dados agregados de extração por concurso e processos/ano.
+
+        Endpoint esperado do ms-escolhas:
+            POST /api/v1/escolhas/extracao-dados/
+
+        Args:
+            concurso_uuid: UUID do concurso (opcional)
+            filtros: Lista de filtros com ano e processo_uuids (opcional)
+
+        Returns:
+            Dados da API com extração
+
+        Raises:
+            RequestException: Em caso de erro na requisição
+        """
+        url = f"{self.base_url}/api/v1/extracao-dados/"
+        payload = {}
+        if concurso_uuid is not None:
+            payload["concurso_uuid"] = concurso_uuid
+        if filtros is not None:
+            payload["filtros"] = filtros
+        logger.info(
+            "Buscando extração de dados em escolhas",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+            },
+        )
+        try:
+            response = http_client.post(
+                url,
+                json=payload,
+                headers=self._default_headers,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+        except RequestException as exc:
+            logger.error(
+                "Erro ao buscar extração de dados em escolhas "
+                "(concurso_uuid=%s): %s",
+                concurso_uuid,
+                exc,
+            )
+            raise
+
+        logger.info(
+            "Extração de dados em escolhas buscada com sucesso",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+                "status_code": response.status_code,
+                "response": str(response.json())[:100],
+            },
+        )
+        return response.json()

--- a/relatorios/services/escolhas_api_service.py
+++ b/relatorios/services/escolhas_api_service.py
@@ -135,3 +135,71 @@ class EscolhasService:
             len(escolhas_filtradas),
         )
         return escolhas_filtradas
+
+    def buscar_extracao_dados(
+        self,
+        concurso_uuid: str | None = None,
+        filtros: list[dict] | None = None,
+    ) -> dict:
+        """
+        Busca dados agregados de extração por concurso e processos/ano.
+
+        Endpoint esperado do ms-escolhas:
+            POST /api/v1/escolhas/extracao-dados/
+
+        Args:
+            concurso_uuid: UUID do concurso (opcional)
+            filtros: Lista de filtros com ano e processo_uuids (opcional)
+
+        Returns:
+            Dados da API com extração
+
+        Raises:
+            RequestException: Em caso de erro na requisição
+        """
+        url = f"{self.base_url}/api/v1/extracao-dados/"
+        payload = {}
+        if concurso_uuid is not None:
+            payload["concurso_uuid"] = concurso_uuid
+        if filtros is not None:
+            payload["filtros"] = filtros
+        logger.info(
+            "Buscando extração de dados em escolhas",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+            },
+        )
+        try:
+            response = http_client.post(
+                url,
+                json=payload,
+                headers=self._default_headers,
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+        except RequestException as exc:
+            logger.error(
+                "Erro ao buscar extração de dados em escolhas "
+                "(concurso_uuid=%s): %s",
+                concurso_uuid,
+                exc,
+            )
+            raise
+
+        logger.info(
+            "Extração de dados em escolhas buscada com sucesso",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "POST",
+                "url": url,
+                "headers": self._default_headers,
+                "payload": payload,
+                "status_code": response.status_code,
+                "response": str(response.json())[:100],
+            },
+        )
+        return response.json()

--- a/relatorios/services/extracao_dados_service.py
+++ b/relatorios/services/extracao_dados_service.py
@@ -1,0 +1,447 @@
+"""
+Serviço de orquestração para extração de dados agregados de microserviços.
+"""
+
+import logging
+from collections import defaultdict
+
+from django.conf import settings
+from requests import RequestException
+from rest_framework.exceptions import NotFound
+
+from relatorios.services.candidatos_api_service import CandidatosService
+from relatorios.services.concurso_api_service import ConcursoService
+from relatorios.services.escolhas_api_service import EscolhasService
+from relatorios.services.processo_convocacao_api_service import (
+    ProcessoConvocacaoService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExtracaoDadosService:
+    """Agrega dados de convocação, candidatos, escolhas e concursos."""
+
+    def __init__(
+        self,
+        convocacao_base_url: str | None = None,
+        candidatos_base_url: str | None = None,
+        escolhas_base_url: str | None = None,
+        concursos_base_url: str | None = None,
+        timeout_seconds: int = 30,
+    ):
+        """Inicializa o serviço de extração de dados.
+
+        Args:
+            convocacao_base_url: URL base do microserviço de convocação
+            candidatos_base_url: URL base do microserviço de candidatos
+            escolhas_base_url: URL base do microserviço de escolhas
+            concursos_base_url: URL base do microserviço de concursos
+            timeout_seconds: Tempo limite em segundos para as requisições
+        """
+        convocacao_url = convocacao_base_url or settings.CONVOCACAO_API_URL
+        candidatos_url = candidatos_base_url or settings.CANDIDATOS_API_URL
+        escolhas_url = escolhas_base_url or settings.ESCOLHAS_API_URL
+        concursos_url = concursos_base_url or settings.CONCURSOS_API_URL
+        self.processo_service = ProcessoConvocacaoService(
+            base_url=convocacao_url, timeout_seconds=timeout_seconds
+        )
+        self.candidatos_service = CandidatosService(
+            base_url=candidatos_url, timeout_seconds=timeout_seconds
+        )
+        self.escolhas_service = EscolhasService(
+            base_url=escolhas_url, timeout_seconds=timeout_seconds
+        )
+        self.concurso_service = ConcursoService(
+            base_url=concursos_url, timeout_seconds=timeout_seconds
+        )
+
+    def extrair_todos(self) -> dict:
+        """
+        Extração geral sem filtros de concurso ou ano.
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            RequestException: Erro de comunicação com microserviços
+        """
+        return self._extrair_geral()
+
+    def extrair(self, concurso_uuid: str, ano: int) -> dict:
+        """
+        Extração filtrada por concurso e ano.
+
+        Args:
+            concurso_uuid: UUID do concurso
+            ano: Ano de referência YYYY
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            NotFound: Quando não há processos para o concurso/ano informados
+            RequestException: Erro de comunicação com microserviços
+        """
+        return self._extrair_por_concurso(concurso_uuid=concurso_uuid, ano=ano)
+
+    def _extrair_geral(self) -> dict:
+        """Extração geral sem filtros de concurso ou ano.
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            RequestException: Erro de comunicação com microserviços
+        """        
+        candidatos_data = self.candidatos_service.buscar_extracao_dados()
+        # candidatos_data = {
+        #     "habilitados": {
+        #         "total": 10000,
+        #         "pcd": 50,
+        #         "nna": 150,
+        #         "geral": 9000
+        #     },
+        #     "convocados": 3000,
+        #     "nao-convocados": 2000
+        # }
+        escolhas_data = self.escolhas_service.buscar_extracao_dados()
+        # escolhas_data = {
+        #     "escolha": 100,
+        #     "reconvocacao": 200,
+        #     "nao-escolha": 20,
+        #     "dres": [
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MIGUEL",
+        #             "escolhas": 100,
+        #             "vagas": 120
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MATEUS",
+        #             "escolhas": 80,
+        #             "vagas": 100
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO SANTO AMARO",
+        #             "escolhas": 8,
+        #             "vagas": 10
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO PIRITUBA/JARAGUA",
+        #             "escolhas": 45,
+        #             "vagas": 55
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO PENHA",
+        #             "escolhas": 80,
+        #             "vagas": 100
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO JACANA/TREMEMBE",
+        #             "escolhas": 20,
+        #             "vagas": 20
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO ITAQUERA",
+        #             "escolhas": 115,
+        #             "vagas": 120
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO GUAIANASES",
+        #             "escolhas": 90,
+        #             "vagas": 100
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO FREGUESIA/BRASILANDIA",
+        #             "escolhas": 95,
+        #             "vagas": 105
+        #         },
+        #         {
+        #             "nome": "DIRETORIA REGIONAL DE EDUCACAO PINHEIROS",
+        #             "escolhas": 82,
+        #             "vagas": 97
+        #         }
+        #     ],
+        #     "dres_concursos": {
+        #         "46cce769-9180-463a-a6ff-43d320742bb7": [
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MIGUEL",
+        #                 "escolhas": 100,
+        #                 "vagas": 120,
+        #                 "codigo_cargo": 1001,
+        #                 "cargo_descricao": "Backend"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MATEUS",
+        #                 "escolhas": 80,
+        #                 "vagas": 100,
+        #                 "codigo_cargo": 1002,
+        #                 "cargo_descricao": "Frontend"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SANTO AMARO",
+        #                 "escolhas": 8,
+        #                 "vagas": 10,
+        #                 "codigo_cargo": 1003,
+        #                 "cargo_descricao": "Mobile"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO PIRITUBA/JARAGUA",
+        #                 "escolhas": 45,
+        #                 "vagas": 55,
+        #                 "codigo_cargo": 1001,
+        #                 "cargo_descricao": "Backend"
+        #             },
+        #         ],
+        #         "33646bd4-5410-455e-acde-7df18e02003b": [
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MIGUEL",
+        #                 "escolhas": 100,
+        #                 "vagas": 120,
+        #                 "codigo_cargo": 1001,
+        #                 "cargo_descricao": "Backend"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MATEUS",
+        #                 "escolhas": 80,
+        #                 "vagas": 100,
+        #                 "codigo_cargo": 1002,
+        #                 "cargo_descricao": "Frontend"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO SANTO AMARO",
+        #                 "escolhas": 8,
+        #                 "vagas": 10,
+        #                 "codigo_cargo": 1003,
+        #                 "cargo_descricao": "Mobile"
+        #             },
+        #             {
+        #                 "nome": "DIRETORIA REGIONAL DE EDUCACAO PIRITUBA/JARAGUA",
+        #                 "escolhas": 45,
+        #                 "vagas": 55,
+        #                 "codigo_cargo": 1001,
+        #                 "cargo_descricao": "Backend"
+        #             },
+        #         ],
+        #     }
+        # }
+
+        concurso_data = self.concurso_service.buscar_extracao_dados()
+        # concurso_data = {
+        #     "autorizacoes-publicadas": 100
+        # }
+
+        return {
+            "candidatos": candidatos_data,
+            "escolhas": escolhas_data,
+            "concurso": concurso_data,
+        }
+
+    def _extrair_por_concurso(
+        self, concurso_uuid: str, ano: int
+    ) -> dict:
+        """Extração filtrada por concurso e ano.
+
+        Args:
+            concurso_uuid: UUID do concurso
+            ano: Ano de referência YYYY
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            NotFound: Quando não há processos para o concurso/ano informados
+            RequestException: Erro de comunicação com microserviços
+        """
+        processos = self._buscar_processos(concurso_uuid)
+        processos_por_ano = self._agrupar_processos_por_ano(processos)
+
+        if ano not in processos_por_ano:
+            raise NotFound(
+                f"Nenhum processo de convocação encontrado para o ano {ano}."
+            )
+
+        filtros = [
+            {"ano": ano_ref, "processo_uuids": uuids}
+            for ano_ref, uuids in sorted(processos_por_ano.items())
+        ]
+
+        candidatos_data = (
+            self.candidatos_service.buscar_extracao_dados(
+                concurso_uuid=concurso_uuid,
+                filtros=filtros,
+            )
+        )
+        candidatos_data2 = {
+            "habilitados": {
+                "total": 10000,
+                "pcd": 50,
+                "nna": 150,
+                "geral": 9000
+            },
+            "2026": {
+                "convocados": 3000,
+                "nao-convocados": 2000
+            }
+        }
+        escolhas_data = self.escolhas_service.buscar_extracao_dados(
+            concurso_uuid=concurso_uuid,
+            filtros=filtros,
+        )
+        escolhas_data2 = {
+            "2026": {
+                "escolha": 100,
+                "reconvocacao": 200,
+                "nao-escolha": 20,
+                "dres": [
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MIGUEL",
+                        "escolhas": 100,
+                        "vagas": 120
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO SAO MATEUS",
+                        "escolhas": 80,
+                        "vagas": 100
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO SANTO AMARO",
+                        "escolhas": 8,
+                        "vagas": 10
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO PIRITUBA/JARAGUA",
+                        "escolhas": 45,
+                        "vagas": 55
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO PENHA",
+                        "escolhas": 80,
+                        "vagas": 100
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO JACANA/TREMEMBE",
+                        "escolhas": 20,
+                        "vagas": 20
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO ITAQUERA",
+                        "escolhas": 115,
+                        "vagas": 120
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO GUAIANASES",
+                        "escolhas": 90,
+                        "vagas": 100
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO FREGUESIA/BRASILANDIA",
+                        "escolhas": 95,
+                        "vagas": 105
+                    },
+                    {
+                        "nome": "DIRETORIA REGIONAL DE EDUCACAO PINHEIROS",
+                        "escolhas": 82,
+                        "vagas": 97
+                    }
+                ]
+            }
+        }
+        concurso_data = self.concurso_service.buscar_extracao_dados(
+            concurso_uuid=concurso_uuid,
+            ano=ano,
+        )
+        concurso_data2 = {
+            "2026": {
+                "autorizacoes-publicadas": 100
+            }
+        }
+
+        return {
+            "candidatos": candidatos_data,
+            "escolhas": escolhas_data,
+            "concurso": concurso_data,
+        }
+
+    def _buscar_processos(self, concurso_uuid: str) -> list[dict]:
+        """Busca processos de convocação por concurso.
+
+        Args:
+            concurso_uuid: UUID do concurso
+
+        Raises:
+            NotFound: Quando não há processos para o concurso informado
+
+        Returns:
+            list[dict]: Lista de processos de convocação
+        """        
+        response = self.processo_service.buscar_processos_por_concurso(
+            concurso_uuid
+        )
+        processos = self._extrair_lista(response.json())
+        if not processos:
+            raise NotFound(
+                "Nenhum processo de convocação encontrado para o concurso "
+                "informado."
+            )
+        return processos
+
+    @staticmethod
+    def _extrair_lista(data) -> list[dict]:
+        if isinstance(data, dict) and "results" in data:
+            return data["results"]
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return [data]
+        return []
+
+    @staticmethod
+    def _agrupar_processos_por_ano(
+        processos: list[dict],
+    ) -> dict[int, list[str]]:
+        """Agrupa processos de convocação por ano.
+
+        Args:
+            processos (list[dict]): Lista de processos de convocação
+
+        Returns:
+            dict[int, list[str]]: Dicionário com os anos como chaves e as listas de UUIDs dos processos como valores
+        """
+        processos_por_ano: dict[int, list[str]] = defaultdict(list)
+
+        for processo in processos:
+            processo_uuid = processo.get("uuid") or processo.get("id")
+            if not processo_uuid:
+                continue
+
+            ano_processo = ExtracaoDadosService._obter_ano_processo(processo)
+            if ano_processo is None:
+                continue
+
+            processos_por_ano[ano_processo].append(str(processo_uuid))
+
+        return dict(processos_por_ano)
+
+    @staticmethod
+    def _obter_ano_processo(processo: dict) -> int | None:
+        """Obtém o ano de um processo de convocação.
+
+        Args:
+            processo (dict): Processo de convocação
+
+        Returns:
+            int | None: Ano do processo de convocação
+        """
+
+        data_convocacao = processo.get("data_convocacao")
+        if not data_convocacao:
+            return None
+
+        if isinstance(data_convocacao, str):
+            return int(data_convocacao[:4])
+
+        if hasattr(data_convocacao, "year"):
+            return data_convocacao.year
+
+        return None

--- a/relatorios/services/extracao_dados_service.py
+++ b/relatorios/services/extracao_dados_service.py
@@ -1,0 +1,238 @@
+"""
+Serviço de orquestração para extração de dados agregados de microserviços.
+"""
+
+import logging
+from collections import defaultdict
+
+from django.conf import settings
+from requests import RequestException
+from rest_framework.exceptions import NotFound
+
+from relatorios.services.candidatos_api_service import CandidatosService
+from relatorios.services.concurso_api_service import ConcursoService
+from relatorios.services.escolhas_api_service import EscolhasService
+from relatorios.services.processo_convocacao_api_service import (
+    ProcessoConvocacaoService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExtracaoDadosService:
+    """Agrega dados de convocação, candidatos, escolhas e concursos."""
+
+    def __init__(
+        self,
+        convocacao_base_url: str | None = None,
+        candidatos_base_url: str | None = None,
+        escolhas_base_url: str | None = None,
+        concursos_base_url: str | None = None,
+        timeout_seconds: int = 30,
+    ):
+        """Inicializa o serviço de extração de dados.
+
+        Args:
+            convocacao_base_url: URL base do microserviço de convocação
+            candidatos_base_url: URL base do microserviço de candidatos
+            escolhas_base_url: URL base do microserviço de escolhas
+            concursos_base_url: URL base do microserviço de concursos
+            timeout_seconds: Tempo limite em segundos para as requisições
+        """
+        convocacao_url = convocacao_base_url or settings.CONVOCACAO_API_URL
+        candidatos_url = candidatos_base_url or settings.CANDIDATOS_API_URL
+        escolhas_url = escolhas_base_url or settings.ESCOLHAS_API_URL
+        concursos_url = concursos_base_url or settings.CONCURSOS_API_URL
+        self.processo_service = ProcessoConvocacaoService(
+            base_url=convocacao_url, timeout_seconds=timeout_seconds
+        )
+        self.candidatos_service = CandidatosService(
+            base_url=candidatos_url, timeout_seconds=timeout_seconds
+        )
+        self.escolhas_service = EscolhasService(
+            base_url=escolhas_url, timeout_seconds=timeout_seconds
+        )
+        self.concurso_service = ConcursoService(
+            base_url=concursos_url, timeout_seconds=timeout_seconds
+        )
+
+    def extrair_total(self) -> dict:
+        """
+        Extração total de dados.
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            RequestException: Erro de comunicação com microserviços
+        """
+        return self._extrair_total()
+
+    def extrair(self, concurso_uuid: str, ano: int) -> dict:
+        """
+        Extração filtrada por concurso e ano.
+
+        Args:
+            concurso_uuid: UUID do concurso
+            ano: Ano de referência YYYY
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            NotFound: Quando não há processos para o concurso/ano informados
+            RequestException: Erro de comunicação com microserviços
+        """
+        return self._extrair_por_concurso(concurso_uuid=concurso_uuid, ano=ano)
+
+    def _extrair_total(self) -> dict:
+        """Extração total de dados sem filtrar por concurso ou ano.
+
+        Returns:
+            dict: Dicionário com os dados de extração de cada microserviço
+
+        Raises:
+            RequestException: Erro de comunicação com microserviços
+        """        
+        candidatos_data = self.candidatos_service.buscar_extracao_dados()
+        escolhas_data = self.escolhas_service.buscar_extracao_dados()
+        concurso_data = self.concurso_service.buscar_extracao_dados()
+
+        return {
+            "candidatos": candidatos_data,
+            "escolhas": escolhas_data,
+            "concurso": concurso_data,
+        }
+
+    def _extrair_por_concurso(
+        self, concurso_uuid: str, ano: int
+    ) -> dict:
+        """Extração filtrada por concurso e ano.
+
+        Args:
+            concurso_uuid: UUID do concurso
+            ano: Ano de referência YYYY
+
+        Returns:
+            Resposta agregada dos microserviços
+
+        Raises:
+            NotFound: Quando não há processos para o concurso/ano informados
+            RequestException: Erro de comunicação com microserviços
+        """
+        processos = self._buscar_processos(concurso_uuid)
+        processos_por_ano = self._agrupar_processos_por_ano(processos)
+
+        if ano not in processos_por_ano:
+            raise NotFound(
+                f"Nenhum processo de convocação encontrado para o ano {ano}."
+            )
+
+        filtros = [
+            {"ano": ano_ref, "processo_uuids": uuids}
+            for ano_ref, uuids in sorted(processos_por_ano.items())
+        ]
+
+        candidatos_data = (
+            self.candidatos_service.buscar_extracao_dados(
+                concurso_uuid=concurso_uuid,
+                filtros=filtros,
+            )
+        )
+        escolhas_data = self.escolhas_service.buscar_extracao_dados(
+            concurso_uuid=concurso_uuid,
+            filtros=filtros,
+        )
+        concurso_data = self.concurso_service.buscar_extracao_dados(
+            concurso_uuid=concurso_uuid,
+            ano=ano,
+        )
+        return {
+            "candidatos": candidatos_data,
+            "escolhas": escolhas_data,
+            "concurso": concurso_data,
+        }
+
+    def _buscar_processos(self, concurso_uuid: str) -> list[dict]:
+        """Busca processos de convocação por concurso.
+
+        Args:
+            concurso_uuid: UUID do concurso
+
+        Raises:
+            NotFound: Quando não há processos para o concurso informado
+
+        Returns:
+            list[dict]: Lista de processos de convocação
+        """
+        response = self.processo_service.buscar_processos_por_concurso(
+            concurso_uuid
+        )
+        processos = self._extrair_lista(response.json())
+        if not processos:
+            raise NotFound(
+                "Nenhum processo de convocação encontrado para o concurso "
+                "informado."
+            )
+        return processos
+
+    @staticmethod
+    def _extrair_lista(data) -> list[dict]:
+        """Extrai a lista de processos de convocação."""
+        if isinstance(data, dict) and "results" in data:
+            return data["results"]
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return [data]
+        return []
+
+    @staticmethod
+    def _agrupar_processos_por_ano(
+        processos: list[dict],
+    ) -> dict[int, list[str]]:
+        """Agrupa processos de convocação por ano.
+
+        Args:
+            processos (list[dict]): Lista de processos de convocação
+
+        Returns:
+            dict[int, list[str]]: Dicionário com os anos como chaves e as listas de UUIDs dos processos como valores
+        """
+        processos_por_ano: dict[int, list[str]] = defaultdict(list)
+
+        for processo in processos:
+            processo_uuid = processo.get("uuid") or processo.get("id")
+            if not processo_uuid:
+                continue
+
+            ano_processo = ExtracaoDadosService._obter_ano_processo(processo)
+            if ano_processo is None:
+                continue
+
+            processos_por_ano[ano_processo].append(str(processo_uuid))
+
+        return dict(processos_por_ano)
+
+    @staticmethod
+    def _obter_ano_processo(processo: dict) -> int | None:
+        """Obtém o ano de um processo de convocação.
+
+        Args:
+            processo (dict): Processo de convocação
+
+        Returns:
+            int | None: Ano do processo de convocação
+        """
+
+        data_convocacao = processo.get("data_convocacao")
+        if not data_convocacao:
+            return None
+
+        if isinstance(data_convocacao, str):
+            return int(data_convocacao[:4])
+
+        if hasattr(data_convocacao, "year"):
+            return data_convocacao.year
+
+        return None

--- a/relatorios/services/processo_convocacao_api_service.py
+++ b/relatorios/services/processo_convocacao_api_service.py
@@ -131,7 +131,7 @@ class ProcessoConvocacaoService:
                 "response": str(response.json())[:100],
             },
         )
-        return response  # type: ignore[no-any-return]
+        return response
 
     def separar_processos_por_principal(
         self, processo_data: dict

--- a/relatorios/tests/services/test_candidatos_api_service.py
+++ b/relatorios/tests/services/test_candidatos_api_service.py
@@ -246,6 +246,76 @@ def test_buscar_por_uuids_http_error(mock_post: Any) -> None:
         svc.buscar_por_uuids(uuids=["u1"])
 
 
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_success(mock_post):
+    mock_resp = _Resp(
+        {
+            "habilitados": {"total": 100, "pcd": 5, "nna": 10, "geral": 85},
+            "2026": {"convocados": 30, "nao-convocados": 20},
+        }
+    )
+    mock_post.return_value = mock_resp
+    svc = _svc()
+    filtros = [
+        {
+            "ano": 2026,
+            "processo_uuids": [
+                "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ],
+        }
+    ]
+    payload_esperado = {
+        "habilitados": {"total": 100, "pcd": 5, "nna": 10, "geral": 85},
+        "2026": {"convocados": 30, "nao-convocados": 20},
+    }
+    resp = svc.buscar_extracao_dados(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        filtros=filtros,
+    )
+    assert resp == payload_esperado
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/habilitados/extracao-dados/",
+        json={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "filtros": filtros,
+        },
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_sem_parametros(mock_post):
+    mock_post.return_value = _Resp({"habilitados": {"total": 50000}})
+    svc = _svc()
+    resp = svc.buscar_extracao_dados()
+    assert resp == {"habilitados": {"total": 50000}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/habilitados/extracao-dados/",
+        json={},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_http_error(mock_post):
+    mock_resp = _Resp(None, status_code=500)
+    mock_post.return_value = mock_resp
+    svc = _svc()
+    with pytest.raises(requests.HTTPError):
+        svc.buscar_extracao_dados(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            filtros=[{"ano": 2026, "processo_uuids": ["p1"]}],
+        )
+
+
 def test_buscar_candidatos_por_agendas_success_extracts_both_formats(
     monkeypatch: Any,
 ) -> Any:

--- a/relatorios/tests/services/test_candidatos_api_service.py
+++ b/relatorios/tests/services/test_candidatos_api_service.py
@@ -239,6 +239,76 @@ def test_buscar_por_uuids_http_error(mock_post):
         svc.buscar_por_uuids(uuids=["u1"])
 
 
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_success(mock_post):
+    mock_resp = _Resp(
+        {
+            "habilitados": {"total": 100, "pcd": 5, "nna": 10, "geral": 85},
+            "2026": {"convocados": 30, "nao-convocados": 20},
+        }
+    )
+    mock_post.return_value = mock_resp
+    svc = _svc()
+    filtros = [
+        {
+            "ano": 2026,
+            "processo_uuids": [
+                "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ],
+        }
+    ]
+    payload_esperado = {
+        "habilitados": {"total": 100, "pcd": 5, "nna": 10, "geral": 85},
+        "2026": {"convocados": 30, "nao-convocados": 20},
+    }
+    resp = svc.buscar_extracao_dados(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        filtros=filtros,
+    )
+    assert resp == payload_esperado
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/habilitados/extracao-dados/",
+        json={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "filtros": filtros,
+        },
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_sem_parametros(mock_post):
+    mock_post.return_value = _Resp({"habilitados": {"total": 50000}})
+    svc = _svc()
+    resp = svc.buscar_extracao_dados()
+    assert resp == {"habilitados": {"total": 50000}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/habilitados/extracao-dados/",
+        json={},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.candidatos_api_service.http_client.post")
+def test_buscar_extracao_dados_http_error(mock_post):
+    mock_resp = _Resp(None, status_code=500)
+    mock_post.return_value = mock_resp
+    svc = _svc()
+    with pytest.raises(requests.HTTPError):
+        svc.buscar_extracao_dados(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            filtros=[{"ano": 2026, "processo_uuids": ["p1"]}],
+        )
+
+
 def test_buscar_candidatos_por_agendas_success_extracts_both_formats(
     monkeypatch,
 ):

--- a/relatorios/tests/services/test_concurso_api_service.py
+++ b/relatorios/tests/services/test_concurso_api_service.py
@@ -1,0 +1,78 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from relatorios.services.concurso_api_service import ConcursoService
+
+
+class _Resp:
+    def __init__(self, payload=None, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code and self.status_code >= 400:
+            raise requests.HTTPError(f"status={self.status_code}")
+
+
+def _svc(base="http://api.local", timeout=15):
+    return ConcursoService(base_url=base, timeout_seconds=timeout)
+
+
+@patch("relatorios.services.concurso_api_service.http_client.post")
+def test_buscar_extracao_dados_success(mock_post):
+    mock_post.return_value = _Resp(
+        payload={"concurso": {"nome": "Concurso X", "codigo": 1001}}
+    )
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        ano=2026,
+    )
+    assert resp == {"concurso": {"nome": "Concurso X", "codigo": 1001}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        },
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.concurso_api_service.http_client.post")
+def test_buscar_extracao_dados_sem_parametros(mock_post):
+    mock_post.return_value = _Resp(
+        payload={"2026": {"autorizacoes-publicadas": 500}}
+    )
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados()
+    assert resp == {"2026": {"autorizacoes-publicadas": 500}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.concurso_api_service.http_client.post")
+def test_buscar_extracao_dados_http_error(mock_post):
+    mock_post.return_value = _Resp(None, status_code=500)
+    svc = _svc()
+    with pytest.raises(requests.HTTPError):
+        svc.buscar_extracao_dados(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ano=2026,
+        )

--- a/relatorios/tests/services/test_escolhas_api_service.py
+++ b/relatorios/tests/services/test_escolhas_api_service.py
@@ -141,3 +141,63 @@ def test_buscar_escolhas_por_candidatos_request_exception(mock_post):
     svc = _svc()
     with pytest.raises(requests.RequestException):
         svc.buscar_escolhas_por_candidatos(candidato_uuids=["a"])
+
+
+# ---------- buscar_extracao_dados ----------
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_success(mock_post):
+    filtros = [
+        {
+            "ano": 2026,
+            "processo_uuids": ["a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"],
+        }
+    ]
+    mock_post.return_value = _Resp(payload={"escolhas": {"total": 100}})
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        filtros=filtros,
+    )
+    assert resp == {"escolhas": {"total": 100}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "filtros": filtros,
+        },
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_sem_parametros(mock_post):
+    mock_post.return_value = _Resp(payload={"2026": {"escolha": 1000}})
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados()
+    assert resp == {"2026": {"escolha": 1000}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_http_error(mock_post):
+    mock_post.return_value = _Resp(None, status_code=500)
+    svc = _svc()
+    with pytest.raises(requests.HTTPError):
+        svc.buscar_extracao_dados(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            filtros=[{"ano": 2026, "processo_uuids": ["p1"]}],
+        )

--- a/relatorios/tests/services/test_escolhas_api_service.py
+++ b/relatorios/tests/services/test_escolhas_api_service.py
@@ -157,3 +157,63 @@ def test_buscar_escolhas_por_candidatos_request_exception(
     svc = _svc()
     with pytest.raises(requests.RequestException):
         svc.buscar_escolhas_por_candidatos(candidato_uuids=["a"])
+
+
+# ---------- buscar_extracao_dados ----------
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_success(mock_post):
+    filtros = [
+        {
+            "ano": 2026,
+            "processo_uuids": ["a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"],
+        }
+    ]
+    mock_post.return_value = _Resp(payload={"escolhas": {"total": 100}})
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        filtros=filtros,
+    )
+    assert resp == {"escolhas": {"total": 100}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "filtros": filtros,
+        },
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_sem_parametros(mock_post):
+    mock_post.return_value = _Resp(payload={"2026": {"escolha": 1000}})
+    svc = _svc(timeout=5)
+    resp = svc.buscar_extracao_dados()
+    assert resp == {"2026": {"escolha": 1000}}
+    mock_post.assert_called_once_with(
+        "http://api.local/api/v1/extracao-dados/",
+        json={},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        timeout=5,
+    )
+
+
+@patch("relatorios.services.escolhas_api_service.http_client.post")
+def test_buscar_extracao_dados_http_error(mock_post):
+    mock_post.return_value = _Resp(None, status_code=500)
+    svc = _svc()
+    with pytest.raises(requests.HTTPError):
+        svc.buscar_extracao_dados(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            filtros=[{"ano": 2026, "processo_uuids": ["p1"]}],
+        )

--- a/relatorios/tests/services/test_extracao_dados_service.py
+++ b/relatorios/tests/services/test_extracao_dados_service.py
@@ -1,0 +1,213 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from rest_framework.exceptions import NotFound
+
+from relatorios.services.extracao_dados_service import ExtracaoDadosService
+
+
+class _Resp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status={self.status_code}")
+
+
+def _processos_response(processos):
+    return _Resp({"results": processos})
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ConcursoService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.EscolhasService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.CandidatosService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_por_concurso_chama_microservicos_com_filtros(
+    mock_processo_cls,
+    mock_candidatos_cls,
+    mock_escolhas_cls,
+    mock_concurso_cls,
+):
+    concurso_uuid = "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response(
+            [
+                {
+                    "uuid": "proc-2026-a",
+                    "data_convocacao": "2026-03-15T10:00:00Z",
+                },
+                {
+                    "uuid": "proc-2026-b",
+                    "data_convocacao": "2026-06-20T10:00:00Z",
+                },
+                {
+                    "uuid": "proc-2025-a",
+                    "data_convocacao": "2025-01-10T10:00:00Z",
+                },
+            ]
+        )
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    mock_candidatos = Mock()
+    mock_candidatos.buscar_extracao_dados.return_value = {
+        "habilitados": {"total": 10000}
+    }
+    mock_candidatos_cls.return_value = mock_candidatos
+
+    mock_escolhas = Mock()
+    mock_escolhas.buscar_extracao_dados.return_value = {
+        "2026": {"escolha": 100}
+    }
+    mock_escolhas_cls.return_value = mock_escolhas
+
+    mock_concurso = Mock()
+    mock_concurso.buscar_extracao_dados.return_value = {
+        "2026": {"autorizacoes-publicadas": 100}
+    }
+    mock_concurso_cls.return_value = mock_concurso
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+        escolhas_base_url="http://escolhas",
+        concursos_base_url="http://concursos",
+    )
+    resultado = service.extrair(concurso_uuid=concurso_uuid, ano=2026)
+
+    assert resultado["candidatos"]["habilitados"]["total"] == 10000
+    assert resultado["escolhas"]["2026"]["escolha"] == 100
+    filtros_esperados = [
+        {
+            "ano": 2025,
+            "processo_uuids": ["proc-2025-a"],
+        },
+        {
+            "ano": 2026,
+            "processo_uuids": ["proc-2026-a", "proc-2026-b"],
+        },
+    ]
+    mock_candidatos.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        filtros=filtros_esperados,
+    )
+    mock_escolhas.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        filtros=filtros_esperados,
+    )
+    mock_concurso.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        ano=2026,
+    )
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ConcursoService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.EscolhasService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.CandidatosService"
+)
+def test_extrair_total_chama_microservicos_sem_parametros(
+    mock_candidatos_cls,
+    mock_escolhas_cls,
+    mock_concurso_cls,
+):
+    mock_candidatos = Mock()
+    mock_candidatos.buscar_extracao_dados.return_value = {
+        "habilitados": {"total": 50000}
+    }
+    mock_candidatos_cls.return_value = mock_candidatos
+
+    mock_escolhas = Mock()
+    mock_escolhas.buscar_extracao_dados.return_value = {
+        "2026": {"escolha": 1000}
+    }
+    mock_escolhas_cls.return_value = mock_escolhas
+
+    mock_concurso = Mock()
+    mock_concurso.buscar_extracao_dados.return_value = {
+        "2026": {"autorizacoes-publicadas": 500}
+    }
+    mock_concurso_cls.return_value = mock_concurso
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+        escolhas_base_url="http://escolhas",
+        concursos_base_url="http://concursos",
+    )
+    resultado = service.extrair_total()
+
+    assert resultado["candidatos"]["habilitados"]["total"] == 50000
+    mock_candidatos.buscar_extracao_dados.assert_called_once_with()
+    mock_escolhas.buscar_extracao_dados.assert_called_once_with()
+    mock_concurso.buscar_extracao_dados.assert_called_once_with()
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_ano_sem_processos_levanta_not_found(mock_processo_cls):
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response(
+            [
+                {
+                    "uuid": "proc-2025-a",
+                    "data_convocacao": "2025-01-10T10:00:00Z",
+                },
+            ]
+        )
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+    )
+
+    with pytest.raises(NotFound):
+        service.extrair(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ano=2026,
+        )
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_concurso_sem_processos_levanta_not_found(mock_processo_cls):
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response([])
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+    )
+
+    with pytest.raises(NotFound):
+        service.extrair(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ano=2026,
+        )

--- a/relatorios/tests/services/test_extracao_dados_service.py
+++ b/relatorios/tests/services/test_extracao_dados_service.py
@@ -1,0 +1,213 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from rest_framework.exceptions import NotFound
+
+from relatorios.services.extracao_dados_service import ExtracaoDadosService
+
+
+class _Resp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status={self.status_code}")
+
+
+def _processos_response(processos):
+    return _Resp({"results": processos})
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ConcursoService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.EscolhasService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.CandidatosService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_por_concurso_chama_microservicos_com_filtros(
+    mock_processo_cls,
+    mock_candidatos_cls,
+    mock_escolhas_cls,
+    mock_concurso_cls,
+):
+    concurso_uuid = "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response(
+            [
+                {
+                    "uuid": "proc-2026-a",
+                    "data_convocacao": "2026-03-15T10:00:00Z",
+                },
+                {
+                    "uuid": "proc-2026-b",
+                    "data_convocacao": "2026-06-20T10:00:00Z",
+                },
+                {
+                    "uuid": "proc-2025-a",
+                    "data_convocacao": "2025-01-10T10:00:00Z",
+                },
+            ]
+        )
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    mock_candidatos = Mock()
+    mock_candidatos.buscar_extracao_dados.return_value = {
+        "habilitados": {"total": 10000}
+    }
+    mock_candidatos_cls.return_value = mock_candidatos
+
+    mock_escolhas = Mock()
+    mock_escolhas.buscar_extracao_dados.return_value = {
+        "2026": {"escolha": 100}
+    }
+    mock_escolhas_cls.return_value = mock_escolhas
+
+    mock_concurso = Mock()
+    mock_concurso.buscar_extracao_dados.return_value = {
+        "2026": {"autorizacoes-publicadas": 100}
+    }
+    mock_concurso_cls.return_value = mock_concurso
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+        escolhas_base_url="http://escolhas",
+        concursos_base_url="http://concursos",
+    )
+    resultado = service.extrair(concurso_uuid=concurso_uuid, ano=2026)
+
+    assert resultado["candidatos"]["habilitados"]["total"] == 10000
+    assert resultado["escolhas"]["2026"]["escolha"] == 100
+    filtros_esperados = [
+        {
+            "ano": 2025,
+            "processo_uuids": ["proc-2025-a"],
+        },
+        {
+            "ano": 2026,
+            "processo_uuids": ["proc-2026-a", "proc-2026-b"],
+        },
+    ]
+    mock_candidatos.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        filtros=filtros_esperados,
+    )
+    mock_escolhas.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        filtros=filtros_esperados,
+    )
+    mock_concurso.buscar_extracao_dados.assert_called_once_with(
+        concurso_uuid=concurso_uuid,
+        ano=2026,
+    )
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ConcursoService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.EscolhasService"
+)
+@patch(
+    "relatorios.services.extracao_dados_service.CandidatosService"
+)
+def test_extrair_geral_chama_microservicos_sem_parametros(
+    mock_candidatos_cls,
+    mock_escolhas_cls,
+    mock_concurso_cls,
+):
+    mock_candidatos = Mock()
+    mock_candidatos.buscar_extracao_dados.return_value = {
+        "habilitados": {"total": 50000}
+    }
+    mock_candidatos_cls.return_value = mock_candidatos
+
+    mock_escolhas = Mock()
+    mock_escolhas.buscar_extracao_dados.return_value = {
+        "2026": {"escolha": 1000}
+    }
+    mock_escolhas_cls.return_value = mock_escolhas
+
+    mock_concurso = Mock()
+    mock_concurso.buscar_extracao_dados.return_value = {
+        "2026": {"autorizacoes-publicadas": 500}
+    }
+    mock_concurso_cls.return_value = mock_concurso
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+        escolhas_base_url="http://escolhas",
+        concursos_base_url="http://concursos",
+    )
+    resultado = service.extrair_todos()
+
+    assert resultado["candidatos"]["habilitados"]["total"] == 50000
+    mock_candidatos.buscar_extracao_dados.assert_called_once_with()
+    mock_escolhas.buscar_extracao_dados.assert_called_once_with()
+    mock_concurso.buscar_extracao_dados.assert_called_once_with()
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_ano_sem_processos_levanta_not_found(mock_processo_cls):
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response(
+            [
+                {
+                    "uuid": "proc-2025-a",
+                    "data_convocacao": "2025-01-10T10:00:00Z",
+                },
+            ]
+        )
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+    )
+
+    with pytest.raises(NotFound):
+        service.extrair(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ano=2026,
+        )
+
+
+@patch(
+    "relatorios.services.extracao_dados_service.ProcessoConvocacaoService"
+)
+def test_extrair_concurso_sem_processos_levanta_not_found(mock_processo_cls):
+    mock_processo = Mock()
+    mock_processo.buscar_processos_por_concurso.return_value = (
+        _processos_response([])
+    )
+    mock_processo_cls.return_value = mock_processo
+
+    service = ExtracaoDadosService(
+        convocacao_base_url="http://convocacao",
+        candidatos_base_url="http://candidatos",
+    )
+
+    with pytest.raises(NotFound):
+        service.extrair(
+            concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            ano=2026,
+        )

--- a/relatorios/tests/views/test_extracao_dados.py
+++ b/relatorios/tests/views/test_extracao_dados.py
@@ -1,0 +1,123 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+def test_extracao_dados_query_serializer_valid():
+    from relatorios.serializers.extracao_dados import (
+        ExtracaoDadosQuerySerializer,
+    )
+
+    serializer = ExtracaoDadosQuerySerializer(
+        data={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["ano"] == 2026
+
+
+def test_extracao_dados_query_serializer_ano_invalido():
+    from relatorios.serializers.extracao_dados import (
+        ExtracaoDadosQuerySerializer,
+    )
+
+    serializer = ExtracaoDadosQuerySerializer(
+        data={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 26,
+        }
+    )
+    assert not serializer.is_valid()
+    assert "ano" in serializer.errors
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_get_com_filtros(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair.return_value = {
+        "candidatos": {"habilitados": {"total": 10000}},
+    }
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-list")
+    response = client.get(
+        url,
+        {
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["candidatos"]["habilitados"]["total"] == 10000
+    mock_service.extrair.assert_called_once_with(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        ano=2026,
+    )
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_todos_get(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair_todos.return_value = {
+        "candidatos": {"habilitados": {"total": 50000}},
+    }
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-todos")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.extrair_todos.assert_called_once_with()
+
+
+def test_extracao_dados_get_sem_parametros_invalido(client):
+    url = reverse("extracao-dados-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_get_erro_microservico(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair.side_effect = requests.RequestException("timeout")
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-list")
+    response = client.get(
+        url,
+        {
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        },
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_todos_get_erro_microservico(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair_todos.side_effect = requests.RequestException(
+        "timeout"
+    )
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-todos")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY

--- a/relatorios/tests/views/test_extracao_dados.py
+++ b/relatorios/tests/views/test_extracao_dados.py
@@ -1,0 +1,123 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+def test_extracao_dados_query_serializer_valid():
+    from relatorios.serializers.extracao_dados import (
+        ExtracaoDadosQuerySerializer,
+    )
+
+    serializer = ExtracaoDadosQuerySerializer(
+        data={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["ano"] == 2026
+
+
+def test_extracao_dados_query_serializer_ano_invalido():
+    from relatorios.serializers.extracao_dados import (
+        ExtracaoDadosQuerySerializer,
+    )
+
+    serializer = ExtracaoDadosQuerySerializer(
+        data={
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 26,
+        }
+    )
+    assert not serializer.is_valid()
+    assert "ano" in serializer.errors
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_get_com_filtros(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair.return_value = {
+        "candidatos": {"habilitados": {"total": 10000}},
+    }
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-list")
+    response = client.get(
+        url,
+        {
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["candidatos"]["habilitados"]["total"] == 10000
+    mock_service.extrair.assert_called_once_with(
+        concurso_uuid="a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+        ano=2026,
+    )
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_total_get(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair_total.return_value = {
+        "candidatos": {"habilitados": {"total": 50000}},
+    }
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-total")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.extrair_total.assert_called_once_with()
+
+
+def test_extracao_dados_get_sem_parametros_invalido(client):
+    url = reverse("extracao-dados-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_get_erro_microservico(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair.side_effect = requests.RequestException("timeout")
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-list")
+    response = client.get(
+        url,
+        {
+            "concurso_uuid": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d",
+            "ano": 2026,
+        },
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+@patch("relatorios.views.extracao_dados.ExtracaoDadosService")
+def test_extracao_dados_total_get_erro_microservico(mock_service_cls, client):
+    mock_service = Mock()
+    mock_service.extrair_total.side_effect = requests.RequestException(
+        "timeout"
+    )
+    mock_service_cls.return_value = mock_service
+
+    url = reverse("extracao-dados-total")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY

--- a/relatorios/urls.py
+++ b/relatorios/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
+    ExtracaoDadosViewSet,
     ParametrizacaoViewSet,
     PersonalizacaoViewSet,
     RelatorioViewSet,
@@ -16,6 +17,9 @@ router.register(
 )
 router.register(
     r"personalizacao", PersonalizacaoViewSet, basename="personalizacao"
+)
+router.register(
+    r"extracao-dados", ExtracaoDadosViewSet, basename="extracao-dados"
 )
 
 urlpatterns = [

--- a/relatorios/urls.py
+++ b/relatorios/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
+    ExtracaoDadosViewSet,
     ParametrizacaoViewSet,
     PersonalizacaoViewSet,
     RelatorioViewSet,
@@ -18,6 +19,9 @@ router.register(
 )
 router.register(
     r"personalizacao", PersonalizacaoViewSet, basename="personalizacao"
+)
+router.register(
+    r"extracao-dados", ExtracaoDadosViewSet, basename="extracao-dados"
 )
 
 urlpatterns = [

--- a/relatorios/views/__init__.py
+++ b/relatorios/views/__init__.py
@@ -1,3 +1,4 @@
+from .extracao_dados import ExtracaoDadosViewSet
 from .parametrizacao import ParametrizacaoViewSet
 from .personalizacao import PersonalizacaoViewSet
 from .relatorios import RelatorioViewSet
@@ -6,4 +7,5 @@ __all__ = [
     "RelatorioViewSet",
     "ParametrizacaoViewSet",
     "PersonalizacaoViewSet",
+    "ExtracaoDadosViewSet",
 ]

--- a/relatorios/views/__init__.py
+++ b/relatorios/views/__init__.py
@@ -1,5 +1,5 @@
 """Módulo views/__init__."""
-
+from .extracao_dados import ExtracaoDadosViewSet
 from .parametrizacao import ParametrizacaoViewSet
 from .personalizacao import PersonalizacaoViewSet
 from .relatorios import RelatorioViewSet
@@ -8,4 +8,5 @@ __all__ = [
     "RelatorioViewSet",
     "ParametrizacaoViewSet",
     "PersonalizacaoViewSet",
+    "ExtracaoDadosViewSet",
 ]

--- a/relatorios/views/extracao_dados.py
+++ b/relatorios/views/extracao_dados.py
@@ -1,0 +1,66 @@
+"""
+View para extração de dados agregados de microserviços.
+"""
+
+import logging
+
+from requests import RequestException
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from relatorios.serializers.extracao_dados import ExtracaoDadosQuerySerializer
+from relatorios.services.extracao_dados_service import ExtracaoDadosService
+
+logger = logging.getLogger(__name__)
+
+
+class ExtracaoDadosViewSet(viewsets.GenericViewSet):
+    """
+    ViewSet para extração de dados.
+
+    GET /extracao-dados/          → list (filtrado por concurso_uuid e ano)
+    GET /extracao-dados/todos/    → action todos (extração geral)
+    """
+
+    permission_classes = [AllowAny]
+
+    def list(self, request, *args, **kwargs):
+        serializer = ExtracaoDadosQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        concurso_uuid = str(serializer.validated_data["concurso_uuid"])
+        ano = serializer.validated_data["ano"]
+
+        try:
+            dados = ExtracaoDadosService().extrair(
+                concurso_uuid=concurso_uuid,
+                ano=ano,
+            )
+        except RequestException as exc:
+            logger.error(
+                "Erro ao extrair dados (concurso_uuid=%s, ano=%s): %s",
+                concurso_uuid,
+                ano,
+                exc,
+            )
+            return Response(
+                {"detail": "Erro ao comunicar com serviço externo."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(dados, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=["get"], url_path="todos")
+    def todos(self, request, *args, **kwargs):
+        try:
+            dados = ExtracaoDadosService().extrair_todos()
+        except RequestException as exc:
+            logger.error("Erro ao extrair dados gerais: %s", exc)
+            return Response(
+                {"detail": "Erro ao comunicar com serviço externo."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(dados, status=status.HTTP_200_OK)

--- a/relatorios/views/extracao_dados.py
+++ b/relatorios/views/extracao_dados.py
@@ -1,0 +1,65 @@
+"""
+View para extração de dados agregados de microserviços.
+"""
+
+import logging
+
+from requests import RequestException
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from relatorios.serializers.extracao_dados import ExtracaoDadosQuerySerializer
+from relatorios.services.extracao_dados_service import ExtracaoDadosService
+
+logger = logging.getLogger(__name__)
+
+
+class ExtracaoDadosViewSet(viewsets.GenericViewSet):
+    """
+    ViewSet para extração de dados.
+
+    GET /extracao-dados/          → list (filtrado por concurso_uuid e ano)
+    GET /extracao-dados/todos/    → action todos (extração geral)
+    """
+
+    permission_classes = [AllowAny]
+
+    def list(self, request, *args, **kwargs):
+        serializer = ExtracaoDadosQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        concurso_uuid = str(serializer.validated_data["concurso_uuid"])
+        ano = serializer.validated_data["ano"]
+
+        try:
+            dados = ExtracaoDadosService().extrair(
+                concurso_uuid=concurso_uuid,
+                ano=ano,
+            )
+        except RequestException as exc:
+            logger.error(
+                "Erro ao extrair dados (concurso_uuid=%s, ano=%s): %s",
+                concurso_uuid,
+                ano,
+                exc,
+            )
+            return Response(
+                {"detail": "Erro ao comunicar com serviço externo."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(dados, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=["get"], url_path="total")
+    def total(self, request, *args, **kwargs):
+        try:
+            dados = ExtracaoDadosService().extrair_total()
+        except RequestException as exc:
+            logger.error("Erro ao extrair dados gerais: %s", exc)
+            return Response(
+                {"detail": "Erro ao comunicar com serviço externo."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        return Response(dados, status=status.HTTP_200_OK)


### PR DESCRIPTION
Implementa no  o fluxo de extração de dados agregados, orquestrando chamadas aos microserviços de convocação, candidatos, escolhas e concursos.


### Endpoints expostos

| Método | Rota | Descrição |
|--------|------|-----------|
| `GET` | `/api/v1/extracao-dados/?concurso_uuid=<uuid>&ano=<YYYY>` | Extração filtrada por concurso e ano |
| `GET` | `/api/v1/extracao-dados/total/` | Extração geral (sem filtros) |

### Fluxo filtrado (`extrair`)

1. Busca processos de convocação do concurso via **ms-convocação**
2. Agrupa processos por ano (`data_convocacao`)
3. Valida se existe processo para o ano informado (retorna `404` caso contrário)
4. Monta `filtros: [{ano, processo_uuids}]` e chama em paralelo lógico:
   - **Candidatos** → `POST /api/v1/habilitados/extracao-dados/`
   - **Escolhas** → `POST /api/v1/extracao-dados/`
   - **Concursos** → `POST /api/v1/extracao-dados/` (com `concurso_uuid` e `ano`)
5. Retorna payload unificado:
```json
{
  "candidatos": { ... },
  "escolhas": { ... },
  "concurso": { ... }
}
```

[AB#150059](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/150059) [AB#148916](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148916) [AB#150064](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/150064)